### PR TITLE
explicitly export allocate() and intArrayFromString()

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ CCFLAGS = -s WASM=1 \
 	-s NO_EXIT_RUNTIME=1 \
 	-s EXPORTED_FUNCTIONS='[]' \
 	-s STRICT=1 \
+	-s EXTRA_EXPORTED_RUNTIME_METHODS='["allocate","intArrayFromString"]' \
 	--pre-js src/pre.js \
 	-W -Wextra -Wall -Wno-unused-function
 


### PR DESCRIPTION
because they are not exported by default as of emscripten 1.3.24:

https://github.com/kripken/emscripten/blob/incoming/ChangeLog.markdown#v13724-12132017