### PR TITLE
fix for emscripten 1.37.27

### DIFF
--- a/src/binding.c
+++ b/src/binding.c
@@ -28,6 +28,12 @@ typedef struct
 } ZopfliJsOutput;
 
 EMSCRIPTEN_KEEPALIVE
+deallocate(void *ptr) {
+    assert(ptr != NULL);
+    free(ptr);
+}
+
+EMSCRIPTEN_KEEPALIVE
 ZopfliJsOutput *createZopfliJsOutput()
 {
     return (ZopfliJsOutput *)calloc(1, sizeof(ZopfliJsOutput));

--- a/src/index.ts
+++ b/src/index.ts
@@ -106,9 +106,9 @@ function callCompress(input: InputType, format: ZopfliFormat, options: ZopfliOpt
   const outputSize = z._getBufferSize(output);
 
   const result = new Uint8Array(z.HEAP8.subarray(outputPtr, outputPtr + outputSize));
-  z._free(outputPtr);
-  z._free(output);
-  z._free(bufferPtr);
+  z._deallocate(outputPtr);
+  z._deallocate(output);
+  z._deallocate(bufferPtr);
 
   // zopfli does not fail unless a violation of preconditions occurs.
   cb(null, result);


### PR DESCRIPTION
Emscripten 1.37.27 no longer exports `_free`.